### PR TITLE
Add unit declarator to module, class and grammar declarations

### DIFF
--- a/lib/JSON5/Tiny.pm6
+++ b/lib/JSON5/Tiny.pm6
@@ -14,7 +14,7 @@ It supports strings, numbers, arrays and hashes (no custom objects).
 
 =end pod
 
-module JSON5::Tiny;
+unit module JSON5::Tiny;
 
 use JSON5::Tiny::Actions;
 use JSON5::Tiny::Grammar;

--- a/lib/JSON5/Tiny/Actions.pm6
+++ b/lib/JSON5/Tiny/Actions.pm6
@@ -1,5 +1,5 @@
 use v6;
-class JSON5::Tiny::Actions;
+unit class JSON5::Tiny::Actions;
 
 method TOP($/) {
     make $/.values.[0].ast;

--- a/lib/JSON5/Tiny/Grammar.pm6
+++ b/lib/JSON5/Tiny/Grammar.pm6
@@ -1,5 +1,5 @@
 use v6;
-grammar JSON5::Tiny::Grammar;
+unit grammar JSON5::Tiny::Grammar;
 
 rule TOP        { ^ [ <object> | <array> ] $ }
 rule object     { '{' ~ '}' <pairlist>       }


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
